### PR TITLE
Implement Query for Calendar Walkthrough

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,80 +14,116 @@
 
 package com.google.sps;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.ArrayList;
-import java.util.HashSet;
 
 public final class FindMeetingQuery {
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    ArrayList<TimeRange> conflicts = new ArrayList<TimeRange>();
-    for (Event e : events) {
-      if (!Collections.disjoint(e.getAttendees(), request.getAttendees())) {
-        conflicts.add(e.getWhen());
-      }
-    }
 
-    // System.out.println("BEFORE");
-    // for (TimeRange t : conflicts) {
-    //   System.out.println(t.toString());
-    // }
+  // Takes in a collection of all events (each with seperate attendees and timeranges) and
+  // 'MeetingRequest' (with required attendees and a duration requirement) and returns a Collection
+  // of TimeRanges that work with schedules of required attendees and meets the duration requirement
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    Collection<TimeRange> result;
+
+    ArrayList<TimeRange> conflicts = generateConflicts(events, request.getAttendees());
 
     if (conflicts.isEmpty()) {
-      Collection<TimeRange> res = new ArrayList<TimeRange>();
-      TimeRange possible = TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true);
-      if (possible.duration() >= request.getDuration()) {
-        res.add(possible);
+      // If no conflicts, create an time range for entire day and add to result if possible (meets
+      // duration requirement)
+      result = new ArrayList<TimeRange>();
+      TimeRange fullDay =
+          TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true);
+      addIfPossible(result, fullDay, request.getDuration());
+    } else {
+      // if conflicts exist, generate free time ranges taking into account conflicts / minimum
+      // duration
+      result = generateFreeTimeRanges(conflicts, request.getDuration());
+    }
+    return result;
+  }
+
+  // Generates arraylist of conflicting events (events attendees of requested meeting are also
+  // attending)
+  private ArrayList<TimeRange> generateConflicts(
+      Collection<Event> events, Collection<String> attendees) {
+    ArrayList<TimeRange> conflicts = new ArrayList<TimeRange>();
+
+    for (Event possibleConflict : events) {
+      // checks if set of attendees of the current 'possible conflicting event' and attendees to
+      // requested event are disjoint (no shared members)
+      if (!Collections.disjoint(possibleConflict.getAttendees(), attendees)) {
+        // adds to conflicts if not disjoint (member in possible conflict is attending requested
+        // meeting)
+        conflicts.add(possibleConflict.getWhen());
       }
-      return res;
     }
 
+    return conflicts;
+  }
+
+  private ArrayList<TimeRange> generateFreeTimeRanges(
+      ArrayList<TimeRange> conflicts, long duration) {
+    ArrayList<TimeRange> freeTimes = new ArrayList<TimeRange>();
+
+    // merge overlapping / contained conflicts into each other, and order them by starting time
+    mergeConflicts(conflicts);
+
+    // generate TimeRange from start of day to start of first event, and add if possible
+    TimeRange startToFirst =
+        TimeRange.fromStartEnd(TimeRange.START_OF_DAY, conflicts.get(0).start(), false);
+    addIfPossible(freeTimes, startToFirst, duration);
+
+    // loop through pairs of adjacent conflicts, create time ranges between end of first and
+    // beginning of second, and add to free times if possible
+    int idx = 0;
+    while (idx < conflicts.size() - 1) {
+      TimeRange current = conflicts.get(idx);
+      TimeRange next = conflicts.get(idx + 1);
+      TimeRange possibleRange = TimeRange.fromStartEnd(current.end(), next.start(), false);
+      addIfPossible(freeTimes, possibleRange, duration);
+      idx++;
+    }
+
+    // generate TimeRange from end of last event to end of day, and add if possible
+    TimeRange lastToEnd =
+        TimeRange.fromStartEnd(
+            conflicts.get(conflicts.size() - 1).end(), TimeRange.END_OF_DAY, true);
+    addIfPossible(freeTimes, lastToEnd, duration);
+
+    return freeTimes;
+  }
+
+  // Merge conflicts (if there's overlap / one conflict contains another, merges into singular
+  // conflict)
+  private void mergeConflicts(ArrayList<TimeRange> conflicts) {
+    // Sort by starting time
     Collections.sort(conflicts, TimeRange.ORDER_BY_START);
-    int curr = 0;
-    while (curr < conflicts.size() - 1) {
-      TimeRange current = conflicts.get(curr);
-      TimeRange next = conflicts.get(curr+1);
-      
+
+    int idx = 0;
+    while (idx < conflicts.size() - 1) {
+      TimeRange current = conflicts.get(idx);
+      TimeRange next = conflicts.get(idx + 1);
       if (current.overlaps(next)) {
-        TimeRange merged = TimeRange.fromStartEnd(current.start(), Math.max(current.end(), next.end()), false);
-        conflicts.remove(curr+1);
-        conflicts.set(curr,merged);
+        // if overlap between current and next event, 'merge' them (remove prev two events and
+        // create new event starting at first events start time, and the maximum of the two events
+        // ending time)
+        TimeRange merged =
+            TimeRange.fromStartEnd(current.start(), Math.max(current.end(), next.end()), false);
+        conflicts.remove(idx + 1);
+        conflicts.set(idx, merged);
       } else {
-        curr++;
+        // otherwise, move onto next event
+        idx++;
       }
     }
+  }
 
-    Collection<TimeRange> result = new HashSet<TimeRange>();
-    if (!conflicts.isEmpty()) {
-      TimeRange startToFirst = TimeRange.fromStartEnd(TimeRange.START_OF_DAY, conflicts.get(0).start(), false);
-      if (startToFirst.duration() >= request.getDuration()) {
-        result.add(startToFirst);
-      }
-      curr = 0;
-      while (curr < conflicts.size() - 1) {
-        TimeRange current = conflicts.get(curr);
-        TimeRange next = conflicts.get(curr + 1);
-        TimeRange possibleRange = TimeRange.fromStartEnd(current.end(), next.start(), false);
-        if (possibleRange.duration() >= request.getDuration()) {
-          result.add(possibleRange);
-        }
-        curr++;
-      }
-      TimeRange lastToEnd = TimeRange.fromStartEnd(conflicts.get(conflicts.size() - 1).end(), TimeRange.END_OF_DAY, true);
-      if (lastToEnd.duration() >= request.getDuration()) {
-        result.add(lastToEnd);
-      }
+  // Checks if time range is valid (satisfies minimum duration requirement), and adds to collection
+  // of TimeRanges if possible
+  private void addIfPossible(Collection<TimeRange> collection, TimeRange range, long duration) {
+    if (range.duration() >= duration) {
+      collection.add(range);
     }
-    ArrayList<TimeRange> res = new ArrayList<TimeRange>(result);
-    Collections.sort(res, TimeRange.ORDER_BY_START);
-    return res;
-
-
-    // System.out.println("AFTER");
-    // for (TimeRange t : conflicts) {
-    //   System.out.println(t.toString());
-    // }
-    
-    // throw new UnsupportedOperationException("TODO: Implement this method.");
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,6 +18,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+* Queries calendar to return possible meeting TimeRange's for a meeting request.
+* 
+* <p>Contains the query method (used to query calendar with a meeting request) along with helper 
+* methods to aid in querying the calendar.
+*/
 public final class FindMeetingQuery {
 
   /**

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,79 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashSet;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    ArrayList<TimeRange> conflicts = new ArrayList<TimeRange>();
+    for (Event e : events) {
+      if (!Collections.disjoint(e.getAttendees(), request.getAttendees())) {
+        conflicts.add(e.getWhen());
+      }
+    }
+
+    // System.out.println("BEFORE");
+    // for (TimeRange t : conflicts) {
+    //   System.out.println(t.toString());
+    // }
+
+    if (conflicts.isEmpty()) {
+      Collection<TimeRange> res = new ArrayList<TimeRange>();
+      TimeRange possible = TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true);
+      if (possible.duration() >= request.getDuration()) {
+        res.add(possible);
+      }
+      return res;
+    }
+
+    Collections.sort(conflicts, TimeRange.ORDER_BY_START);
+    int curr = 0;
+    while (curr < conflicts.size() - 1) {
+      TimeRange current = conflicts.get(curr);
+      TimeRange next = conflicts.get(curr+1);
+      
+      if (current.overlaps(next)) {
+        TimeRange merged = TimeRange.fromStartEnd(current.start(), Math.max(current.end(), next.end()), false);
+        conflicts.remove(curr+1);
+        conflicts.set(curr,merged);
+      } else {
+        curr++;
+      }
+    }
+
+    Collection<TimeRange> result = new HashSet<TimeRange>();
+    if (!conflicts.isEmpty()) {
+      TimeRange startToFirst = TimeRange.fromStartEnd(TimeRange.START_OF_DAY, conflicts.get(0).start(), false);
+      if (startToFirst.duration() >= request.getDuration()) {
+        result.add(startToFirst);
+      }
+      curr = 0;
+      while (curr < conflicts.size() - 1) {
+        TimeRange current = conflicts.get(curr);
+        TimeRange next = conflicts.get(curr + 1);
+        TimeRange possibleRange = TimeRange.fromStartEnd(current.end(), next.start(), false);
+        if (possibleRange.duration() >= request.getDuration()) {
+          result.add(possibleRange);
+        }
+        curr++;
+      }
+      TimeRange lastToEnd = TimeRange.fromStartEnd(conflicts.get(conflicts.size() - 1).end(), TimeRange.END_OF_DAY, true);
+      if (lastToEnd.duration() >= request.getDuration()) {
+        result.add(lastToEnd);
+      }
+    }
+    ArrayList<TimeRange> res = new ArrayList<TimeRange>(result);
+    Collections.sort(res, TimeRange.ORDER_BY_START);
+    return res;
+
+
+    // System.out.println("AFTER");
+    // for (TimeRange t : conflicts) {
+    //   System.out.println(t.toString());
+    // }
+    
+    // throw new UnsupportedOperationException("TODO: Implement this method.");
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -20,41 +20,53 @@ import java.util.Collections;
 
 public final class FindMeetingQuery {
 
-  // Takes in a collection of all events (each with seperate attendees and timeranges) and
-  // 'MeetingRequest' (with required attendees and a duration requirement) and returns a Collection
-  // of TimeRanges that work with schedules of required attendees and meets the duration requirement
+  /**
+   * Returns TimeRange's which are available to schedule meetings.
+   *
+   * <p>Availability is detirmined by the meeting request. All 'available' TimeRange's must be at
+   * least the length of the requests duration requirement, must not conflict with the required
+   * attendees other events, and should conflict with as few as possible events of the optional
+   * attendees.
+   *
+   * @param events a collection of all other events on the calendar
+   * @param request a list of required attendees, optional attendees, and the duration requirement
+   *     for the meeting
+   * @return Collection<TimeRange> of available TimeRange's for the meeting to be scheduled
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     Collection<TimeRange> result;
 
     ArrayList<TimeRange> conflicts = generateConflicts(events, request.getAttendees());
 
     if (conflicts.isEmpty()) {
-      // If no conflicts, create an time range for entire day and add to result if possible (meets
-      // duration requirement)
       result = new ArrayList<TimeRange>();
+      // if no conflicts exist, attempt to book the entire day
       TimeRange fullDay =
           TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true);
       addIfPossible(result, fullDay, request.getDuration());
     } else {
-      // if conflicts exist, generate free time ranges taking into account conflicts / minimum
-      // duration
       result = generateFreeTimeRanges(conflicts, request.getDuration());
     }
     return result;
   }
 
-  // Generates arraylist of conflicting events (events attendees of requested meeting are also
-  // attending)
+  /**
+   * Generates an arraylist of conflicting events.
+   *
+   * <p>Conflicting events consist of events who's attendees intersect with the required attendees
+   * of the meeting request.
+   *
+   * @param events a collection of all other events on the calendar
+   * @param attendees a list of required attendees
+   * @return all events TimeRange's that conflict
+   */
   private ArrayList<TimeRange> generateConflicts(
       Collection<Event> events, Collection<String> attendees) {
     ArrayList<TimeRange> conflicts = new ArrayList<TimeRange>();
 
     for (Event possibleConflict : events) {
-      // checks if set of attendees of the current 'possible conflicting event' and attendees to
-      // requested event are disjoint (no shared members)
+      // checks if current event's / required attendees intersect
       if (!Collections.disjoint(possibleConflict.getAttendees(), attendees)) {
-        // adds to conflicts if not disjoint (member in possible conflict is attending requested
-        // meeting)
         conflicts.add(possibleConflict.getWhen());
       }
     }
@@ -62,20 +74,27 @@ public final class FindMeetingQuery {
     return conflicts;
   }
 
+  /**
+   * Generates an ArrayList of times available for the meeting.
+   *
+   * <p>Available TimeRange's must not intersect with TimeRange's in conflicts and must be at least
+   * as long as the provided duration.
+   *
+   * @param conflicts a collection of TimeRanges that conflict
+   * @param duration the required duration of the meeting
+   * @return all available TimeRange's for the meeting
+   */
   private ArrayList<TimeRange> generateFreeTimeRanges(
       ArrayList<TimeRange> conflicts, long duration) {
     ArrayList<TimeRange> freeTimes = new ArrayList<TimeRange>();
-
-    // merge overlapping / contained conflicts into each other, and order them by starting time
     mergeConflicts(conflicts);
 
-    // generate TimeRange from start of day to start of first event, and add if possible
+    // Handling TimeRange from start of the day to beggining of first event
     TimeRange startToFirst =
         TimeRange.fromStartEnd(TimeRange.START_OF_DAY, conflicts.get(0).start(), false);
     addIfPossible(freeTimes, startToFirst, duration);
 
-    // loop through pairs of adjacent conflicts, create time ranges between end of first and
-    // beginning of second, and add to free times if possible
+    // Handling all TimeRange's between the days events
     int idx = 0;
     while (idx < conflicts.size() - 1) {
       TimeRange current = conflicts.get(idx);
@@ -85,7 +104,7 @@ public final class FindMeetingQuery {
       idx++;
     }
 
-    // generate TimeRange from end of last event to end of day, and add if possible
+    // Handling TimeRange from end of last event to end of the day
     TimeRange lastToEnd =
         TimeRange.fromStartEnd(
             conflicts.get(conflicts.size() - 1).end(), TimeRange.END_OF_DAY, true);
@@ -94,33 +113,38 @@ public final class FindMeetingQuery {
     return freeTimes;
   }
 
-  // Merge conflicts (if there's overlap / one conflict contains another, merges into singular
-  // conflict)
+  /**
+   * Merges all overlapping and nested events.
+   *
+   * @param conflicts a list of potential conflicting events
+   * @return none
+   */
   private void mergeConflicts(ArrayList<TimeRange> conflicts) {
-    // Sort by starting time
     Collections.sort(conflicts, TimeRange.ORDER_BY_START);
-
+    // loop through all pairs of adjacent events
     int idx = 0;
     while (idx < conflicts.size() - 1) {
       TimeRange current = conflicts.get(idx);
       TimeRange next = conflicts.get(idx + 1);
       if (current.overlaps(next)) {
-        // if overlap between current and next event, 'merge' them (remove prev two events and
-        // create new event starting at first events start time, and the maximum of the two events
-        // ending time)
-        TimeRange merged =
-            TimeRange.fromStartEnd(current.start(), Math.max(current.end(), next.end()), false);
+        int mergedEnd = Math.max(current.end(), next.end());
+        TimeRange merged = TimeRange.fromStartEnd(current.start(), mergedEnd, false);
         conflicts.remove(idx + 1);
         conflicts.set(idx, merged);
       } else {
-        // otherwise, move onto next event
         idx++;
       }
     }
   }
 
-  // Checks if time range is valid (satisfies minimum duration requirement), and adds to collection
-  // of TimeRanges if possible
+  /**
+   * Adds range to collection if duration of range is long enough.
+   *
+   * @param collection collection of timeranges to be potentially modified
+   * @param range potential TimeRange to be added to collection
+   * @param duration required duration TimeRange must be at least as big as
+   * @return none
+   */
   private void addIfPossible(Collection<TimeRange> collection, TimeRange range, long duration) {
     if (range.duration() >= duration) {
       collection.add(range);

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -14,11 +14,9 @@
 
 package com.google.sps;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,14 +79,19 @@ public final class FindMeetingQueryTest {
   @Test
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -103,18 +106,24 @@ public final class FindMeetingQueryTest {
     // Day     : |-----------------------------|
     // Options : |--1--|     |--2--|     |--3--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
@@ -130,18 +139,24 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -157,18 +172,24 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_B)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)));
 
     MeetingRequest request =
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -183,17 +204,23 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options : |--1--|         |--2--|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -208,11 +235,16 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options :       |-----|
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
@@ -227,8 +259,12 @@ public final class FindMeetingQueryTest {
   public void ignoresPeopleNotAttending() {
     // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
-    Collection<Event> events = Arrays.asList(new Event("Event 1",
-        TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)));
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
@@ -257,11 +293,16 @@ public final class FindMeetingQueryTest {
     // Day     : |---------------------|
     // Options :
 
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-            Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
-            Arrays.asList(PERSON_A)));
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
 
@@ -271,4 +312,3 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 }
-


### PR DESCRIPTION
Implement simplest version of query function for "calendar walkthrough"

Implement a query function that takes in two pieces of info to generate possible meeting times:
* **List of Events**: each event has a list of attendees and 'TimeRange' representing duration of each event
* **MeetingRequest**: has a list of required attendees and duration of meeting

Query function must return list of valid TimeRange's where all attendees can attend and is at least as long as the duration from the meeting request.

Create multi-step algorithm that:
1. Generate possible 'conflicts' by checking / adding all events whose attendees include any of the required attendees
2. Check if conflicts were empty in which case:
a. if no conflicts, add a TimeRange spanning entire day and added to list if possible (eg. added if meeting duration was shorter than entire day)
b. if conflicts exist, sorted conflicts by start time and "merged" conflicts so that no TimeRanges overlapped / were contained within another TimeRange, and using merged event conflicts, generated and added valid TimeRange's between conflicts

**Note**: this project included prewritten tests, and current algorithm passes all test cases (evidence in picture)
![image](https://user-images.githubusercontent.com/29647568/84693130-04ec7200-af15-11ea-8fd6-35ad8acab6fc.png)
